### PR TITLE
Prevent modal from becoming larger than screen

### DIFF
--- a/src/lib/components/MarkdownEditor.svelte
+++ b/src/lib/components/MarkdownEditor.svelte
@@ -15,6 +15,7 @@
         new Vditor(elem.id, {
             theme: "classic",
             minHeight: 300,
+            height: 500,
             lang: "en_US",
             mode: "wysiwyg",
             input: text => {


### PR DESCRIPTION
This pull request fixes an issue where the modal was becoming larger than the screen. The height of the modal has been set to a maximum of 500 pixels to ensure it fits within the screen.