### PR TITLE
Fix cascading delete violation

### DIFF
--- a/src/routes/api/templates/[id]/+server.ts
+++ b/src/routes/api/templates/[id]/+server.ts
@@ -111,7 +111,18 @@ export async function DELETE({ params }) {
     const id = params.id
     logger.info(`Deleting template with id ${id}`)
     const query = {
-        text: "DELETE FROM templates WHERE id = $1",
+        text: `
+WITH RECURSIVE descendants AS (
+    SELECT id
+    FROM templates
+    WHERE id = $1
+    UNION ALL
+    SELECT templates.id
+    FROM templates
+    INNER JOIN descendants ON templates.parent_id = descendants.id
+)
+DELETE FROM templates
+WHERE id IN (SELECT descendants.id FROM descendants);`,
         values: [id]
     }
 

--- a/src/routes/templates/TemplatesDirectory/AdminButtons.svelte
+++ b/src/routes/templates/TemplatesDirectory/AdminButtons.svelte
@@ -98,8 +98,13 @@
             body: `Are you sure you want to delete "${shortenText(node.text)}" and any subdirectories?`,
             response: async value => {
                 if (!value) return
-                await fetch(`/api/templates/${node.id}`, { method: "DELETE" }).then(() => {
-                    if (!node.parent) {
+                await fetch(`/api/templates/${node.id}`, { method: "DELETE" }).then(response => {
+                    if (!response.ok) {
+                        toastStore.trigger({
+                            message: "Failed to delete the template.",
+                            background: "variant-filled-error"
+                        })
+                    } else if (!node.parent) {
                         toastStore.trigger({
                             message: "Cannot delete the root node.",
                             background: "variant-filled-error"


### PR DESCRIPTION
This pull request fixes a cascading delete issue that was causing a violation of a foreign key constraint. The issue has been resolved by updating the DELETE query in the `+server.ts` file to use a recursive query that deletes all descendants of the template being deleted. Additionally, in the `AdminButtons.svelte` file, a toast message is triggered if the deletion fails.