### PR TITLE
feat: Add Pyrite (Alpha) page

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,16 +44,16 @@ jobs:
             - run: |
                   npm install --legacy-peer-deps
                   npm run lint
-    
+
     dispatch:
         if: ${{ github.ref_name == 'main' }}
         needs: [testing, lint]
         runs-on: ubuntu-latest
         steps:
-        - name: Dispatch
-          uses: peter-evans/repository-dispatch@v3
-          with:
-            token: ${{ secrets.CTK_BUILD_PAT }}
-            repository: childmindresearch/ctk-build
-            event-type: dependency_updated
-            client-payload: '{"triggered_by": "${{ github.repository }}, on push event", "commit_sha": "${{ github.sha }}", "branch": "${{ github.ref }}"}'
+            - name: Dispatch
+              uses: peter-evans/repository-dispatch@v3
+              with:
+                  token: ${{ secrets.CTK_BUILD_PAT }}
+                  repository: childmindresearch/ctk-build
+                  event-type: dependency_updated
+                  client-payload: '{"triggered_by": "${{ github.repository }}, on push event", "commit_sha": "${{ github.sha }}", "branch": "${{ github.ref }}"}'

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+postgres-data
 ./**/.env*
 .vscode
 .idea

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
             - .env
         volumes:
             - ./postgresql:/var/lib/postgresql/data
-            - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+            - ./e2e/init.sql:/docker-entrypoint-initdb.d/init.sql
         networks:
             - default
 

--- a/src/lib/components/Navigation.svelte
+++ b/src/lib/components/Navigation.svelte
@@ -6,6 +6,7 @@
     const pages = [
         { name: "DSM Codes", href: "/dsm" },
         { name: "Intake", href: "/intake" },
+        { name: "Pyrite Reports (Alpha)", href: "/pyrite" },
         { name: "Summarization", href: "/summarization" },
         { name: "Templates", href: "/templates" }
     ]

--- a/src/routes/api/pyrite/[id]/+server.ts
+++ b/src/routes/api/pyrite/[id]/+server.ts
@@ -1,0 +1,19 @@
+import { logger } from "$lib/server/logging"
+import { AZURE_FUNCTION_PYTHON_URL } from "$lib/server/environment"
+
+export async function GET({ params, fetch }) {
+    const id = params.id
+    logger.info(`Getting Pyrite report with id ${id}.`)
+    return await fetch(`${AZURE_FUNCTION_PYTHON_URL}/pyrite/${id}`)
+        .then(async response => {
+            if (response.ok && response.body) {
+                return new Response(response.body)
+            } else {
+                throw new Error(await response.text())
+            }
+        })
+        .catch(error => {
+            logger.error(`Error getting intake with id ${id}: ${error}`)
+            return new Response(error, { status: 500 })
+        })
+}

--- a/src/routes/pyrite/+page.svelte
+++ b/src/routes/pyrite/+page.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+    import LoadingBar from "$lib/components/LoadingBar.svelte"
+    import { downloadBlob } from "$lib/utils"
+    import { getToastStore } from "@skeletonlabs/skeleton"
+
+    let mrn = $state("")
+    let isLoading = $state(false)
+
+    const toastStore = getToastStore()
+
+    async function onSubmit() {
+        if (mrn === "") {
+            toastStore.trigger({
+                background: "variant-filled-error",
+                message: "Please enter an MRN."
+            })
+            return
+        }
+        isLoading = true
+        await fetch(`/api/pyrite/${mrn}`)
+            .then(async response => {
+                if (!response.ok) {
+                    throw new Error(await response.text())
+                }
+                return await response.blob()
+            })
+            .then(blob => {
+                const filename = `${mrn}_Pyrite_CTK.docx`
+                downloadBlob(blob, filename)
+            })
+            .catch(error => {
+                toastStore.trigger({
+                    background: "variant-filled-error",
+                    message: error.message
+                })
+            })
+        isLoading = false
+    }
+</script>
+
+<h3 class="h3">Pyrite Reports</h3>
+
+<aside class="variant-ghost-error alert">
+    <div class="alert-message">
+        <h3 class="h3">Alpha Feature</h3>
+        <p>
+            This is an alpha feature. It should not be used for day-to-day operations. It may change, error, or break at
+            any time.
+        </p>
+    </div>
+</aside>
+
+<p>
+    This page is used to generate Pyrite reports. Please enter the MRN of the participant you would like to generate a
+    report for.
+</p>
+{#if isLoading}
+    <LoadingBar label="Loading... This may take a while." />
+{:else}
+    <form class="space-y-2">
+        <input class="input w-72" placeholder="MRN" bind:value={mrn} data-testid="pyriteInput" />
+        <br />
+        <button class="btn variant-filled-primary" onclick={onSubmit} disabled={isLoading} data-testid="pyriteSubmit">
+            Submit
+        </button>
+    </form>
+{/if}


### PR DESCRIPTION
Note: This PR is ready for review, but merging will be held until the Pyrite backend (https://github.com/childmindresearch/ctk-functions/pull/198) is ready for merging. 

This adds the frontend's Pyrite page. There are three main files for this:

- `src/routes/pyrite/+page.svelte`
  - Defines the page as a form that takes an MRN, makes a request to the API, and downloads the returned blob.
- `src/routes/api/pyrite/[id]/+server.ts`
  - Defines the Node endpoint. This endpoint simply forwards the request to the Python API (the Python API is not directly accessible from the frontend)
- `src/lib/components/Navigation.svelte`
  - Adds the new Pyrite page to the side-bar. 

Along the way I found that the docker-compose's init.sql volume mount was no longer pointing to the correct location, so I threw this in as a minor bug fix along with an additional .gitignore. 