### PR TITLE
Fix y-axis overflow issue

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -43,7 +43,7 @@
         <Navigation isOpen={true} />
     </div>
 
-    <div class="overflow-y-auto px-10 pt-5 flex-1">
+    <div class="overflow-y-auto h-full px-10 pt-5 flex-1">
         {@render children()}
     </div>
 </div>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -43,7 +43,7 @@
         <Navigation isOpen={true} />
     </div>
 
-    <div class="overflow-y-hidden px-10 pt-5 flex-1">
+    <div class="overflow-y-auto px-10 pt-5 flex-1">
         {@render children()}
     </div>
 </div>


### PR DESCRIPTION
Change the overflow property to ensure the y-axis content is properly displayed instead of remaining hidden.