### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,6 +33,8 @@ jobs:
 
     lint:
         runs-on: ubuntu-latest
+        permissions:
+            contents: read
         steps:
             - uses: actions/checkout@v5
             - name: Use Node.js


### PR DESCRIPTION
Potential fix for [https://github.com/childmindresearch/ctk-webapp/security/code-scanning/8](https://github.com/childmindresearch/ctk-webapp/security/code-scanning/8)

To resolve this issue, explicitly specify the minimal required permissions for the `lint` job. Since this job only checks out code and runs the linter (and does not create issues, change content, or interact with pull requests or secrets), `contents: read` is the minimal necessary privilege. Insert a `permissions` block inside the `lint` job, specifying `contents: read`. This ensures that even if repository or organization defaults are less restrictive, this job only receives non-mutating access. Edit the block under `lint` directly after `runs-on: ubuntu-latest` and before `steps:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
