### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -49,6 +49,7 @@ jobs:
         if: ${{ github.ref_name == 'main' }}
         needs: [testing, lint]
         runs-on: ubuntu-latest
+        permissions: {}
         steps:
             - name: Dispatch
               uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
Potential fix for [https://github.com/childmindresearch/ctk-webapp/security/code-scanning/2](https://github.com/childmindresearch/ctk-webapp/security/code-scanning/2)

To fix the issue, you should add a `permissions` block for the `dispatch` job under `jobs.dispatch:`. This will explicitly restrict the permissions granted to the `GITHUB_TOKEN` during this job, rather than inheriting possibly overly permissive defaults from the repository or organization. The minimal starting point is usually `permissions: {}` (no permissions), unless the job actually requires specific permissions for the `GITHUB_TOKEN` (for example, reading contents, issues, etc.); since this job uses a PAT and does not interact directly with repo resources, `{}` is safe and sensible. All edits are in `.github/workflows/tests.yaml`, specifically adding a `permissions` block to the `dispatch` job (line 48-53 region).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
