### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through a stack trace

### DIFF
--- a/src/routes/api/referrals/providers/[id]/+server.ts
+++ b/src/routes/api/referrals/providers/[id]/+server.ts
@@ -38,7 +38,7 @@ export async function PUT({ params, request }) {
         providerRequest = createProviderSchema.parse(providerData)
     } catch (error) {
         logger.error("Invalid provider data format", error)
-        return new Response(JSON.stringify({ error: "Invalid request format", details: error }), {
+        return new Response(JSON.stringify({ error: "Invalid request format" }), {
             status: 400,
             headers: { "Content-Type": "application/json" }
         })


### PR DESCRIPTION
Potential fix for [https://github.com/childmindresearch/ctk-webapp/security/code-scanning/7](https://github.com/childmindresearch/ctk-webapp/security/code-scanning/7)

To fix this problem, the code that returns a response to the client with `details: error` should be modified so as *not* to include the entire error object. Instead, we should only send a generic error message or, at most, a sanitized subset of error information. The stack trace and internal details should be logged server-side (which is already done with `logger.error`), but not sent to the client. The fix is to remove the `details: error` from the response body in line 41 and, optionally, replace it with a generic message or with specific information about which fields failed validation, if safe.

**Required changes:**
- Update lines 41-44 of the PUT handler to remove `details: error` from the client-facing response and only return a generic message ("Invalid request format").
- Optionally, you can provide a list of validation error messages by parsing Zod errors, for improved UX and safety ("details: error.errors" if present and safe), but the simplest fix is to remove it.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
